### PR TITLE
Pin the Arm toolchain to 14.3.Rel1 and adopt the ThreadX install pattern

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -105,6 +105,16 @@ jobs:
   build-arm-nucleo:
     name: Build ST Nucleo-F401RE (ARM Cortex-M4)
     runs-on: ubuntu-24.04
+
+    env:
+      # Pinned deliberately, as the runner image is: a toolchain upgrade should
+      # be a reviewable commit rather than something that changes underneath the
+      # targets. Kept in step with eclipse-threadx/threadx ci_cortex_m.yml, which
+      # pins the same release for the Cortex-M ports.
+      # Releases: https://developer.arm.com/downloads/-/arm-gnu-toolchain-downloads
+      GCC_VERSION: 14.3.rel1
+      GCC_TARGET: arm-none-eabi
+
     steps:
       - name: Checkout Repository
         uses: actions/checkout@v4
@@ -116,13 +126,33 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y cmake ninja-build
 
-      - name: Install Pinned Arm GNU Toolchain 14.2.Rel1
+      - name: Cache the Arm GNU toolchain
+        id: cache-arm-gcc
+        uses: actions/cache@v4
+        with:
+          path: toolchain
+          key: arm-gnu-toolchain-${{ env.GCC_VERSION }}-x86_64-${{ env.GCC_TARGET }}
+
+      - name: Install the Arm GNU toolchain
+        if: steps.cache-arm-gcc.outputs.cache-hit != 'true'
         run: |
-          wget -q https://developer.arm.com/-/media/Files/downloads/gnu/14.2.rel1/binrel/arm-gnu-toolchain-14.2.rel1-x86_64-arm-none-eabi.tar.xz
-          mkdir -p $HOME/arm-gcc
-          tar -xJf arm-gnu-toolchain-14.2.rel1-x86_64-arm-none-eabi.tar.xz -C $HOME/arm-gcc --strip-components=1
-          rm arm-gnu-toolchain-14.2.rel1-x86_64-arm-none-eabi.tar.xz
-          echo "$HOME/arm-gcc/bin" >> $GITHUB_PATH
+          set -eu
+          base="https://developer.arm.com/-/media/Files/downloads/gnu/${GCC_VERSION}/binrel"
+          archive="arm-gnu-toolchain-${GCC_VERSION}-x86_64-${GCC_TARGET}.tar.xz"
+          mkdir -p toolchain && cd toolchain
+          curl -fsSLO "$base/$archive"
+          curl -fsSLO "$base/$archive.sha256asc"
+          sha256sum -c "$archive.sha256asc"
+          tar xf "$archive"
+          rm -f "$archive"
+
+      - name: Put the toolchain on PATH
+        run: |
+          set -eu
+          echo "$GITHUB_WORKSPACE/toolchain/arm-gnu-toolchain-${GCC_VERSION}-x86_64-${GCC_TARGET}/bin" >> "$GITHUB_PATH"
+
+      - name: Report the toolchain version
+        run: ${{ env.GCC_TARGET }}-gcc --version
 
       - name: Build NUCLEO-F401RE Demo
         run: |

--- a/targets/STMicroelectronics/NUCLEO_F401RE/README.md
+++ b/targets/STMicroelectronics/NUCLEO_F401RE/README.md
@@ -196,8 +196,8 @@ The BSP overrides `HAL_InitTick()` to configure TIM2 as the HAL timebase and pro
 ## Validation Record
 
 ### Verification Environment
-- **Toolchain**: Arm GNU Toolchain 14.2.Rel1 (GCC 14.2.1), the version pinned by CI
-- **Static ROM usage**: 22068 Bytes (4.21% of 512 KB Flash), including the startup self-tests
+- **Toolchain**: Arm GNU Toolchain 14.3.Rel1 (GCC 14.3.1), the version pinned by CI and by the ThreadX Cortex-M ports
+- **Static ROM usage**: 22064 Bytes (4.21% of 512 KB Flash), including the startup self-tests
 - **Static RAM usage**: 6000 Bytes (6.10% of 96 KB RAM)
 - **Dynamic Stack & Buffer allocation**: Stacks (8 x 1024 bytes) and Queue buffer (40 bytes) are dynamically allocated from the `TX_BYTE_POOL` (consuming 8312 bytes total, including pool headers).
 - **Board Hardware**: NUCLEO-F401RE


### PR DESCRIPTION
# Pin the Arm toolchain to 14.3.Rel1 and adopt the ThreadX install pattern

## Why

The ARM job pinned **14.2.Rel1**, chosen only because it was the newest release I was aware of when #50 added the pin. `eclipse-threadx/threadx` already pins **14.3.rel1** in `ci_cortex_m.yml` for the Cortex-M ports — so samplex was lagging the flagship repository rather than choosing between two versions.

Both satisfy the AGENTS.md GCC 14 requirement. Matching `threadx` means a toolchain bump becomes one reviewable line in each repository instead of a per-repository decision.

## What changed

The install steps now mirror `ci_cortex_m.yml` rather than paraphrasing it, which fixes three weaknesses in the version this replaces:

| Before | After |
| :--- | :--- |
| No integrity check on the archive at all | `sha256sum -c` against the published `.sha256asc` |
| ~150 MB downloaded on every run | `actions/cache` keyed on the pinned version |
| `wget -q`, no version recorded | `curl -fsSL` (fails the step on HTTP errors) plus a step reporting the compiler version into the log |

Version and target move into job `env` vars (`GCC_VERSION`, `GCC_TARGET`) using the same names `threadx` uses, so the two files stay diffable.

## Validation record re-measured

| | 14.2.1 | 14.3.1 |
| :--- | ---: | ---: |
| ROM | 22068 B | **22064 B** |
| RAM | 6000 B | 6000 B |

The figures and the pin move together deliberately — letting them drift is what left a stale 15.2.1 measurement in this README before.

## Verification

Locally under Arm GNU Toolchain 14.3.Rel1 (GCC 14.3.1 20250623):

* Clean build with `-Wall -Wshadow -Wdouble-promotion -Werror` — the point release introduces no new diagnostics.
* Headless Renode suite passes, exit 0, all seven startup self-tests green.
* Confirmed both the archive and its `.sha256asc` return 200 from the pinned URL.

## Not in scope

PolarFire's RISC-V toolchain stays on xPack 14.2.0 — a different vendor on a different release cadence, and AGENTS.md's GCC 14 requirement is satisfied. The xPack and Renode downloads in the other jobs could take the same caching and checksum treatment; worth a follow-up, but kept out of this change so the diff stays reviewable.
